### PR TITLE
Fixed signerOrProvider is null error

### DIFF
--- a/example/src/routes/+page.svelte
+++ b/example/src/routes/+page.svelte
@@ -33,7 +33,7 @@
 <AccountConnect />
 <hr />
 
-{#if $account.isConnected}
+{#if $account.status === "connected"}
   {#each components as Component}
     <Component />
     <hr />

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -2,7 +2,6 @@ import {
   getProvider,
   fetchSigner,
   getContract,
-  Signer,
   GetContractResult,
   watchContractEvent,
   WatchContractEventCallback,
@@ -52,7 +51,6 @@ export const contract = <TAbi extends Abi>(contractConfig: { address: string; ab
   const provider = getProvider();
   const contractInstance = getContract<TAbi>({ ...contractConfig, signerOrProvider: provider });
   const store = writable({ isLoading: false });
-
   const setIsLoading = (isLoading: boolean) => store.update((x) => ({ ...x, isLoading }));
 
   // Loop through each key of the functions property and return their
@@ -76,7 +74,11 @@ export const contract = <TAbi extends Abi>(contractConfig: { address: string; ab
         );
 
         const signer = await fetchSigner();
-        const ret = await contractInstance.connect(signer as Signer)[key](...parsedArgs);
+        if (!signer) {
+          throw new Error("account must be connected when calling a contract");
+        }
+
+        const ret = await contractInstance.connect(signer)[key](...parsedArgs);
 
         setIsLoading(false);
         return ret;


### PR DESCRIPTION
Fixed an issue where contract functions were being called before the account had fully reconnected if `autoConnect` was set to true. It appears that there are some situations where the `isConnected` and `isReconnecting` values from wagmis `getAccount()` function can both be true at the same time.

- Added a better account connected conditional to the example
- Added a more intuitive error if the user attempts to call a function before the account is properly connected