### PR TITLE
Fixed network issue when attempting to fetch an ENS

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { Abi } from "abitype";
 import { Address, fetchEnsAddress, fetchEnsAvatar, fetchEnsName } from "@wagmi/core";
+import { mainnet } from "@wagmi/chains";
 
 import { Nullable } from "./types";
 
@@ -17,7 +18,7 @@ import { Nullable } from "./types";
  */
 export const addressOrEns = async (addressOrEns: string): Promise<string | null> => {
   return addressOrEns.endsWith(".eth")
-    ? await fetchEnsAddress({ name: addressOrEns })
+    ? await fetchEnsAddress({ chainId: mainnet.id, name: addressOrEns })
     : addressOrEns;
 };
 


### PR DESCRIPTION
When a contract function call attempts to use the ENS auto-fetcher, previously it was using the connected network. This PR forces the ENS fetch to be performed on mainnet.