### PR TITLE
Wagmi connectors not exported

### DIFF
--- a/src/connectors.ts
+++ b/src/connectors.ts
@@ -1,1 +1,8 @@
 export * from "@wagmi/core/connectors";
+export * from "@wagmi/core/connectors/coinbaseWallet";
+export * from "@wagmi/core/connectors/metaMask";
+export * from "@wagmi/core/connectors/mock";
+export * from "@wagmi/core/connectors/safe";
+export * from "@wagmi/core/connectors/walletConnect";
+export * from "@wagmi/core/connectors/walletConnectLegacy";
+


### PR DESCRIPTION
Only the injected connector was being exported, perhaps due to a file structure change within `@wagmi/core`. This PR contains changes to re-export all the connectors again so they can be accessed via the `@sveeeth/connectors` module.