### PR TITLE
DAI balance example fetches connected account balance

### DIFF
--- a/example/src/components/DaiBalance.svelte
+++ b/example/src/components/DaiBalance.svelte
@@ -3,11 +3,14 @@
   import { DAI_CONFIG } from "../constants";
 
   const dai = contract(DAI_CONFIG);
+
+  $: ({ address } = $account);
+  $: balance = $account.address && dai.read.balanceOf(address);
 </script>
 
 <h3>DAI Balance</h3>
 
-{#await $account.address && dai.read.balanceOf("bbque.eth")}
+{#await balance}
   <p>Loading...</p>
 {:then balance}
   <p>Balance: {balance} DAI</p>


### PR DESCRIPTION
In the example project the DAI balance now fetches the balance of the connected account rather than a hardcoded address.